### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,28 +1,28 @@
-#JSPatchX
+# JSPatchX
 
 [JSPatch](https://github.com/bang590/JSPatch) XCode 代码自动补全插件。
 
 ![Screenshot](https://raw.github.com/bang590/JSPatchX/master/Resource/Screenshot.gif)
 
-##安装
+## 安装
 
-###Alcatraz
+### Alcatraz
 
 可以通过 [Alcatraz](http://alcatraz.io/) 安装，直接搜索 `JSPatchX`。
 
 XCode8+ 用户需要去掉 xcode 签名才可以使用，详见 http://www.jianshu.com/p/dc2fc2a680fc 。
 
-###手工安装
+### 手工安装
 
 下载插件：[JSPatchX.zip](https://raw.github.com/bang590/JSPatchX/master/Resource/JSPatchX.zip)，解压后把 `JSPatchX.xcplugin` 文件放到 /Users/用户名/Library/Application Support/Developer/Shared/Xcode/Plug-ins 目录下（没有这个目录就创建）。重启 XCode 即可。
 
 XCode8 以上用户请使用 Alcatraz 安装。
 
-##使用
+## 使用
 
 1. 在 XCode 里编辑 JS 文件会触发插件自动补全功能，编辑其他文件不影响
 2. 为了使写出来的 JS 格式不乱，建议关掉 XCode 对 ":" 的缩进：XCode -> Preferences -> Text Editing -> indentation -> Automatic indent for -> 去掉 ":" 的勾。
 
-##关于
+## 关于
 
 本插件初版由 [@bang](https://github.com/bang590) 和 [@louis](https://github.com/gabailey) 开发。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#JSPatchX [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
+# JSPatchX [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
 [中文介绍](https://github.com/bang590/JSPatchX/blob/master/README-CN.md)
 
@@ -6,25 +6,25 @@ XCode plugin that provides autocompletion for [JSPatch](https://github.com/bang5
 
 ![Screenshot](https://raw.github.com/bang590/JSPatchX/master/Resource/Screenshot.gif)
 
-##Installation
+## Installation
 
-###Alcatraz
+### Alcatraz
 
 This plugin can be installed using [Alcatraz](http://alcatraz.io/). Search for `JSPatchX` in Alcatraz.
 
-###Manually
+### Manually
 
 Download the plugin: [JSPatchX.zip](https://raw.github.com/bang590/JSPatchX/master/Resource/JSPatchX.zip), unzip it and put `JSPatchX.xcplugin` to `/Users/{YourUserName}/Library/Application Support/Developer/Shared/Xcode/Plug-ins` (create it if not exists), restart XCode.
 
-##Usage
+## Usage
 
 1. The plugin will run while editing JS file in XCode, it take no effect when editing other types of file.
 2. Recommend to turn off the indentation of ":" : `XCode -> Preferences -> Text Editing -> indentation -> Automatic indent for -> turn off ":"`
 
-##License
+## License
 
 To know more about the [LICENSE](LICENSE) agreement.
 
-##About
+## About
 
 Code by [@bang](https://github.com/bang590) & [@louis](https://github.com/gabailey)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
